### PR TITLE
Plugin converted to CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ VWOAmplitudePlugin(amplitude);
 ```
 For more details around `@amplitude/analytics-browser` plugin, refer to this [document](https://www.npmjs.com/package/@amplitude/analytics-browser)
 
+Ensure that the code is rendered and executed exclusively on the client side, as this plugin is designed for client-side functionality only.
+
 ## Code of Conduct
 
 [Code of Conduct](https://github.com/wingify/vwo-amplitude-integration/blob/master/CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VWO Amplitude integration plugin
 
-This plugin allows to send VWO data to Amplitude using amplitude-js.
+This plugin allows to send VWO data to Amplitude using `amplitude-js` or `@amplitude/analytics-browser`.
 
 ## Package Installation
 
@@ -16,24 +16,32 @@ yarn add vwo-amplitude-integration
 
 ## Usage
 
-Initialize  VWOAmplitudePlugin with your amplitude Instance:
+This plugin works with Amplitude's `amplitude-js` and `@amplitude/analytics-browser` libraries.
+
+Initialize VWOAmplitudePlugin with your amplitude Instance:
 
 **In your App.js file**
 ```js
 import amplitude from "amplitude-js";
-import { VWOAmplitudePlugin } from 'vwo-amplitude-integration';
+import VWOAmplitudePlugin from 'vwo-amplitude-integration';
 amplitude.getInstance().init(API_KEY, null, {
-// optional configuration options
-    includeUtm: true,
-    includeGclid: true,
-    includeReferrer: true,
+    // optional configuration options
 });
 
 VWOAmplitudePlugin(amplitude); 
-
 ```
+For more details around `amplitude-js` plugin, refer to this [document](https://www.npmjs.com/package/amplitude-js)
 
-For more details around Amplitude js plugin, refer to this [document](https://www.npmjs.com/package/amplitude-js)
+```js
+import amplitude from "@amplitude/analytics-browser";
+import VWOAmplitudePlugin from 'vwo-amplitude-integration';
+amplitude.init(API_KEY, null, {
+    // optional configuration options
+});
+
+VWOAmplitudePlugin(amplitude); 
+```
+For more details around `@amplitude/analytics-browser` plugin, refer to this [document](https://www.npmjs.com/package/@amplitude/analytics-browser)
 
 ## Code of Conduct
 

--- a/index.js
+++ b/index.js
@@ -47,4 +47,4 @@ function VWOAmplitudePlugin(amplitude){
     ])
 }
 
-export default VWOAmplitudePlugin
+module.exports = VWOAmplitudePlugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vwo-amplitude-integration",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "VWO Amplitude integration",
   "types": "index.d.ts",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vwo-amplitude-integration",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "VWO Amplitude integration",
   "types": "index.d.ts",
   "main": "index.js",


### PR DESCRIPTION
Fixes #2 

1. The plugin is converted to CommonJS to avoid the transpilation step.
2. README updated