### PR TITLE
feat: add option for simplified key name without experiment id

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ensure that the code is rendered and executed exclusively on the client side, as
 
 The VWOAmplitudePlugin function accepts an optional second parameter with the following options:
 
-- `useSimpleKey` (boolean, default: false): When set to true, uses a simplified key name of "VWO-Test-ID" instead of "VWO-Test-ID-{expId}".
+- `useLegacyKeys` (boolean, default: true): When set to false, uses separates user properties for Test and Variatn IDs into `VWO-Test-ID` and `VWO-Variant-ID` with the values being the test and variant IDs respectively.  If true, it will continue to use the key name as `VWO-Test-ID-{expId}` with value being the variant ID.
 
 ```js
 VWOAmplitudePlugin(amplitude, { useSimpleKey: true });

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ For more details around `@amplitude/analytics-browser` plugin, refer to this [do
 
 Ensure that the code is rendered and executed exclusively on the client side, as this plugin is designed for client-side functionality only.
 
+**Options**
+
+The VWOAmplitudePlugin function accepts an optional second parameter with the following options:
+
+- `useSimpleKey` (boolean, default: false): When set to true, uses a simplified key name of "VWO-Test-ID" instead of "VWO-Test-ID-{expId}".
+
+```js
+VWOAmplitudePlugin(amplitude, { useSimpleKey: true });
+```
+
 ## Code of Conduct
 
 [Code of Conduct](https://github.com/wingify/vwo-amplitude-integration/blob/master/CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Ensure that the code is rendered and executed exclusively on the client side, as
 
 The VWOAmplitudePlugin function accepts an optional second parameter with the following options:
 
-- `useLegacyKeys` (boolean, default: true): When set to false, uses separates user properties for Test and Variatn IDs into `VWO-Test-ID` and `VWO-Variant-ID` with the values being the test and variant IDs respectively.  If true, it will continue to use the key name as `VWO-Test-ID-{expId}` with value being the variant ID.
+- `useLegacyKeys` (boolean, default: true): When set to false, uses separates user properties for Test and Variant IDs into `VWO-Test-ID` and `VWO-Variant-ID` with the values being the test and variant IDs respectively.  If true, it will continue to use the legacy single key name as `VWO-Test-ID-{expId}` with value being the variant ID.
 
 ```js
-VWOAmplitudePlugin(amplitude, { useSimpleKey: true });
+VWOAmplitudePlugin(amplitude, { useLegacyKeys: false });
 ```
 
 ## Code of Conduct

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
 declare module "vwo-amplitude-integration" {
-  export default function VWOAmplitudePlugin(amplitude: {[k: string]: any}): void;
+  interface VWOAmplitudePluginOptions {
+    useSimpleKey?: boolean;
+  }
+
+  export default function VWOAmplitudePlugin(amplitude: {[k: string]: any}, options?: VWOAmplitudePluginOptions): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module "vwo-amplitude-integration" {
   interface VWOAmplitudePluginOptions {
-    useSimpleKey?: boolean;
+    useLegacyKeys?: boolean;
   }
 
   export default function VWOAmplitudePlugin(amplitude: {[k: string]: any}, options?: VWOAmplitudePluginOptions): void;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-function VWOAmplitudePlugin(amplitude){
+function VWOAmplitudePlugin(amplitude, options = {}) {
+    const { useSimpleKey = false } = options;
+
     window.VWO = window.VWO || []
     window.VWO.push([
         "onVariationApplied",
@@ -27,8 +29,9 @@ function VWOAmplitudePlugin(amplitude){
                 variationId &&
                 ["VISUAL_AB", "VISUAL", "SPLIT_URL"].indexOf(window._vwo_exp[expId].type) > -1
             ) {
-                _vis_data["VWO-Test-ID-" + expId] = window._vwo_exp[expId].comb_n[variationId];
-                const key = "VWO-Test-ID-" + expId;
+                const key = useSimpleKey ? "VWO-Test-ID" : "VWO-Test-ID-" + expId;
+                _vis_data[key] = window._vwo_exp[expId].comb_n[variationId];
+
                 if (amplitude) {
                     let identify = new amplitude.Identify();
                     identify.set(key, _vis_data[key]);

--- a/index.js
+++ b/index.js
@@ -58,13 +58,9 @@ function VWOAmplitudePlugin(amplitude, options = {}) {
           identify.set(testKeyId, _vis_data[testKeyId]);
           identify.set(variationKeyId, _vis_data[variationKeyId]);
         }
-        if (amplitude.getInstance) {
-          amplitude.getInstance().identify(identify);
-          amplitude.getInstance().logEvent("VWO", _vis_data);
-        } else {
-          amplitude.identify(identify);
-          amplitude.logEvent("VWO", _vis_data);
-        }
+        const amplitudeInstance = amplitude.getInstance?.() || amplitude;
+        amplitudeInstance.identify(identify);
+        amplitudeInstance.logEvent("VWO", _vis_data);
       }
     },
   ]);

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function VWOAmplitudePlugin(amplitude, options = {}) {
                     testKeyId = "VWO-Test-ID";
                     variationKeyId = "VWO-Variation-ID";
                     _vis_data[testKeyId] = expId;
-                    _vis_data[variationKeyId] = variationId;
+                    _vis_data[variationKeyId] = window._vwo_exp[expId].comb_n[variationId];
                 }
 
                 if (amplitude) {


### PR DESCRIPTION
Adds an `options` param with support for `userSimpleKey` which eliminates the experiment ID from the key name.

This reduces the overall impact of vwo on amplitude user properties while retaining backwards compatibility.